### PR TITLE
Write blog article on measurement as leadership tool

### DIFF
--- a/_posts/2026-01-01-measurement-leadership-tool.md
+++ b/_posts/2026-01-01-measurement-leadership-tool.md
@@ -1,0 +1,76 @@
+---
+layout: post
+title: Measurement Is a Leadership Tool, Not an Engineering KPI
+date: 2026-01-01 00:00
+author: avegaraju
+comments: true
+categories: [Engineering, Leadership, Metrics, DORA]
+---
+
+# Measurement Is a Leadership Tool, Not an Engineering KPI
+
+This article came out of a very practical need.
+
+As our organization started to scale, the management team wanted a clearer view into engineering velocity. The goal was not to apply pressure, but to understand how the engineering department was performing and whether there was any scope for further optimization.
+
+The underlying intent was straightforward. If we are already delivering well, can we become even more effective? Can we continue to ship high-value features while reducing wasted effort, unnecessary delays, and invisible friction?
+
+## Why Metrics Entered the Conversation
+
+At that point, I was already tracking DORA metrics as part of my role as a technical leader. These were not newly introduced metrics, and they were not added in response to poor performance. In fact, across all four DORA signals, the engineering organization was in a healthy state.
+
+Deployment frequency was strong, lead times were predictable, change failure rates were low, and recovery times were well within acceptable bounds. From a metrics perspective, the team was performing at a level I would consider elite for an organization of our size and complexity.
+
+When the management team asked for visibility into engineering velocity, I consolidated these signals and presented them along with the necessary context. The objective was not to justify performance, but to provide a clear, honest view of how delivery actually worked in practice.
+
+## What Became Clear While Preparing the Data
+
+Preparing the data and walking through it carefully led to a deeper realization.
+
+The metrics confirmed that the engineering system was healthy. At the same time, they highlighted patterns that could not be explained by engineering effort alone. Certain fluctuations, even within a strong baseline, reflected decisions made earlier in the lifecycle and outside the immediate control of individual teams.
+
+This forced me to think more carefully about what these numbers really represented.
+
+The metrics were accurate. The interpretation required more nuance.
+
+## What the Metrics Were Actually Reflecting
+
+Over time, I started to see these metrics less as indicators of engineering performance and more as reflections of organizational behavior.
+
+Deployment frequency correlated strongly with how quickly priorities were clarified and decisions were made. Lead time reflected coordination overhead, dependency management, and clarity of ownership more than technical difficulty. Change failure rate pointed to system boundaries and architectural choices rather than individual mistakes. MTTR was influenced heavily by preparedness, documentation, and trust during incidents.
+
+These signals were not telling us whether engineers were working hard. They were showing us how effectively the organization enabled them to work.
+
+## Where Measurement Often Goes Wrong
+
+Measurement tends to fail when metrics are treated as scorecards rather than signals.
+
+When numbers are used to judge teams instead of informing leadership decisions, they lose their value. When teams are measured on outcomes they do not fully control, trust erodes. And when metrics are reviewed without adjusting upstream decisions, they become passive reports instead of active tools.
+
+Strong metrics do not eliminate leadership responsibility. They increase it.
+
+## A More Useful Way to Think About Measurement
+
+What worked well for us was treating metrics as a starting point for conversation rather than an endpoint.
+
+Instead of asking why a number changed, we asked what conditions produced that change. Instead of focusing on individual teams, we looked at cross-team friction and decision latency. Instead of reacting to short-term variation, we examined long-term patterns.
+
+This approach preserved psychological safety while still allowing us to improve an already strong system.
+
+## Why I Am Writing This
+
+I am writing these notes primarily for engineering leaders who are new to the responsibility of measuring engineering performance.
+
+When you first encounter frameworks like DORA, it is easy to assume they are designed to tell you whether your teams are performing well or poorly. In reality, they are far more valuable when used to understand how leadership decisions shape delivery outcomes.
+
+Coming from a context of healthy metrics, this distinction became especially clear to me.
+
+## The Shift That Matters
+
+High-performing teams do not optimize metrics. They optimize clarity.
+
+Metrics make the absence of clarity visible. They surface decision bottlenecks, structural friction, and hidden risk that would otherwise remain abstract.
+
+If reviewing engineering metrics feels uncomfortable, it is often because they are highlighting decisions that need attention. That discomfort is not a sign of failure. It is a signal that leadership has an opportunity to improve an already strong system.
+
+That, ultimately, is what measurement is for.


### PR DESCRIPTION
…ng KPI

This article explores how engineering metrics like DORA should be used as leadership tools for understanding organizational behavior rather than as scorecards for team performance. It emphasizes that metrics reveal how effectively organizations enable teams to work, not just whether engineers are working hard.

Key topics covered:
- The context for introducing metrics in scaling organizations
- What DORA metrics actually reflect about organizational behavior
- Common pitfalls in how measurement is used
- A more effective approach to treating metrics as conversation starters
- The importance of optimizing clarity over optimizing metrics