### PR TITLE
Remove duplicate H1 title from blog post content

### DIFF
--- a/_posts/2026-01-01-measurement-leadership-tool.md
+++ b/_posts/2026-01-01-measurement-leadership-tool.md
@@ -7,8 +7,6 @@ comments: true
 categories: [Engineering, Leadership, Metrics, DORA]
 ---
 
-# Measurement Is a Leadership Tool, Not an Engineering KPI
-
 This article came out of a very practical need.
 
 As our organization started to scale, the management team wanted a clearer view into engineering velocity. The goal was not to apply pressure, but to understand how the engineering department was performing and whether there was any scope for further optimization.


### PR DESCRIPTION
The title was appearing three times on the page:
1. From the Jekyll layout template
2. As excerpt text
3. As H1 in the content

Removed the H1 from content since the layout already displays the title from front matter.